### PR TITLE
Various formatting fixes

### DIFF
--- a/lib/BarPlot.js
+++ b/lib/BarPlot.js
@@ -165,11 +165,6 @@ function makeSpec (units, perCapita, width, height) {
       bar: {
         continuousBandSize: continuousBandSize
       }
-      // axis: {labelFont: "Lato", titleFont: "sans-serif"},
-      // legend: {labelFont: "sans-serif", titleFont: "sans-serif"},
-      // header: {labelFont: "sans-serif", titleFont: "sans-serif"},
-      // mark: {font: "sans-serif"},
-      // title: {font: "sans-serif", subtitleFont: "sans-serif"},
     }
   }
 }

--- a/lib/BarPlot.js
+++ b/lib/BarPlot.js
@@ -112,7 +112,12 @@ function makeSpec (units, perCapita, width, height) {
           titleAlign: 'left'
         }
       },
-      color: { field: 'key', type: 'nominal', axis: { title: 'Unit count' } }
+      color: {
+        field: 'key',
+        type: 'nominal',
+        axis: { title: 'Unit count' },
+        legend: { titleFontSize: 12, labelFontSize: 12 }
+      }
     },
     scales: [
       {
@@ -160,7 +165,7 @@ function makeSpec (units, perCapita, width, height) {
       bar: {
         continuousBandSize: continuousBandSize
       }
-      // axis: {labelFont: "sans-serif", titleFont: "sans-serif"},
+      // axis: {labelFont: "Lato", titleFont: "sans-serif"},
       // legend: {labelFont: "sans-serif", titleFont: "sans-serif"},
       // header: {labelFont: "sans-serif", titleFont: "sans-serif"},
       // mark: {font: "sans-serif"},

--- a/lib/BarPlot.js
+++ b/lib/BarPlot.js
@@ -27,6 +27,7 @@ export const keyMapping = {}
 for (const [key, value] of Object.entries(baseKeyMapping)) {
   keyMapping[key] = value
   keyMapping[key + '_per_capita'] = value
+  keyMapping[key + '_per_capita_per_1000'] = value
 }
 
 const fields = Array.from(fieldsGenerator())
@@ -42,18 +43,47 @@ export default function BarPlot ({ data, units, perCapita }) {
 }
 
 function makeSpec (units, perCapita, width, height) {
+  const perThousand = perCapita && (units === 'units')
   const perCapitaSuffix = perCapita ? '_per_capita' : ''
-  const filterFields = Array.from(fieldsGenerator([units], [''], [perCapitaSuffix]))
+  const perThousandSuffix = perThousand ? '_per_1000' : ''
+  const suffix = perCapitaSuffix + perThousandSuffix
+
+  const filterFields = Array.from(fieldsGenerator([units], [''], [suffix], perCapita))
 
   const plotWidth = Math.min(width * 0.92, 936)
   const continuousBandSize = plotWidth * 10 / 936
 
-  const suffix = perCapita ? '_per_capita' : ''
-
   const yLabel = unitsLabels[units]
-  const yTitle = perCapita ? yLabel + ' per capita' : yLabel
+  const yTitleSuffix = perCapita ? (perThousand ? ' per 1000 residents' : ' per capita') : ''
+  const yTitle = yLabel + yTitleSuffix
 
   const yFormat = units === 'value' ? (perCapita ? '$.2f' : '$s') : null
+
+  let transforms = [
+    { fold: fields },
+    {
+      filter: {
+        field: 'key',
+        oneOf: filterFields
+      }
+    },
+    {
+      calculate: JSON.stringify(keyMapping) + '[datum.key] || "Error"',
+      as: 'key_pretty_printed'
+    }
+  ]
+
+  if (perThousand) {
+    const baseFields = Array.from(fieldsGenerator([units], [''], ['_per_capita']))
+    const perThousandTransforms = baseFields.map((field) => {
+      return {
+        calculate: '1000 * datum[\'' + field + '\']',
+        as: field + '_per_1000'
+      }
+    })
+
+    transforms = perThousandTransforms.concat(transforms)
+  }
 
   return {
     width: plotWidth,
@@ -66,9 +96,22 @@ function makeSpec (units, perCapita, width, height) {
       x: {
         field: 'year',
         type: 'temporal',
-        axis: { title: 'Year' }
+        axis: { title: 'Year', titleFontSize: 13, labelFontSize: 14 }
       },
-      y: { field: 'value', type: 'quantitative', axis: { title: yTitle, format: yFormat } },
+      y: {
+        field: 'value',
+        type: 'quantitative',
+        axis: {
+          title: yTitle,
+          format: yFormat,
+          titleFontSize: 13,
+          labelFontSize: 14,
+          titleAngle: 0,
+          titleX: -50,
+          titleY: -13,
+          titleAlign: 'left'
+        }
+      },
       color: { field: 'key', type: 'nominal', axis: { title: 'Unit count' } }
     },
     scales: [
@@ -79,19 +122,7 @@ function makeSpec (units, perCapita, width, height) {
         range: ['1 unit', '2 units', '3-4 units', '5+ units']
       }
     ],
-    transform: [
-      { fold: fields },
-      {
-        filter: {
-          field: 'key',
-          oneOf: filterFields
-        }
-      },
-      {
-        calculate: JSON.stringify(keyMapping) + '[datum.key] || "Error"',
-        as: 'key_pretty_printed'
-      }
-    ],
+    transform: transforms,
     data: { name: 'table' }, // note: vega-lite data attribute is a plain object instead of an array
     usermeta: { embedOptions: { renderer: 'svg' } },
     layer: [

--- a/lib/plots.js
+++ b/lib/plots.js
@@ -1,7 +1,7 @@
 export function * fieldsGenerator (
   types = ['bldgs', 'units', 'value'],
   suffixes = ['_reported', ''],
-  perCapitaSuffixes = ['_per_capita', '']
+  perCapitaSuffixes = ['', '_per_capita', '_per_capita_per_1000']
 ) {
   for (const numUnits of [
     '1_unit',

--- a/pages/data-sources.js
+++ b/pages/data-sources.js
@@ -2,7 +2,7 @@ import { Nav, GitHubFooter } from '../lib/common_elements.js'
 import Head from 'next/head'
 
 export default function DataSources () {
-  const faq = 'font-semibold mt-4'
+  const faq = 'font-semibold mt-4 mb-1'
   const link = 'text-blue-500 hover:text-blue-300'
   const para = 'mb-2'
 
@@ -26,7 +26,22 @@ export default function DataSources () {
         <h2 className={faq}>How accurate is the data?</h2>
         <p className={para}>I'm not sure! They claim that only <a className={link} href='https://www.census.gov/construction/bps/how_the_data_are_collected/#nonresponse'>5% of rows</a> in the 2019 annual data survey had to be imputed because of nonresponse, but that doesn't mean that the officials in each city know how to fill out the form accurately. From other folks who've played with this data, I've gathered that the data is generally more reliable for bigger cities, whose bureaucracy is presumably more competent at filling out these forms, and less so for small towns.</p>
         <h2 className={faq}>I think some of the numbers here look wrong?</h2>
-        <p>The Census Bureau has their own <a className={link} href='https://socds.huduser.gov/permits/'>tool</a> for making tables from the BPS, so trying the same state/city and year there and comparing the two numbers might be a good start.</p>
+        <p className={para}>The Census Bureau has their own <a className={link} href='https://socds.huduser.gov/permits/'>tool</a> for making tables from the BPS, so trying the same state/city and year there and comparing the two numbers might be a good start.</p>
+        <h2 className={faq}>Where is the population data from?</h2>
+        <p className={para}>Most of the data is from Census yearly intercensal estimates. The only exception is places/cities only for the years 1981–1989, for which intercensal estimates weren't available, so I had to take the Census's decade estimates (for 1980 and 1990) and linearly interpolate between those two. In most cases the approximation shouldn't affect things too much (this isn't <em>that</em> different from how the census creates intercensal estimates) but for extremely small cities that may cause some issues.</p>
+        <h2 className={faq}>Can I play with the data?</h2>
+        <p className={para}>Yes! The data for states, metros, counties, and places/cities are available at:</p>
+        <ul className={para + ' list-disc list-inside ml-2'}>
+          <li><a className={link} href='https://housingdata.app/states_annual.parquet'><code>https://housingdata.app/states_annual.parquet</code></a></li>
+          <li><a className={link} href='https://housingdata.app/metros_annual.parquet'><code>https://housingdata.app/metros_annual.parquet</code></a></li>
+          <li><a className={link} href='https://housingdata.app/counties_annual.parquet'><code>https://housingdata.app/counties_annual.parquet</code></a></li>
+          <li><a className={link} href='https://housingdata.app/places_annual.parquet'><code>https://housingdata.app/places_annual.parquet</code></a></li>
+        </ul>
+        <p className={para}>If you're familiar with <code>pandas</code>, it's as easy as</p>
+        <pre className={para}>
+          import pandas as pd<br />
+          df = pd.read_parquet('https://housingdata.app/states_annual.parquet')
+        </pre>
       </div>
       <GitHubFooter />
     </div>

--- a/pages/data-sources.js
+++ b/pages/data-sources.js
@@ -2,7 +2,7 @@ import { Nav, GitHubFooter } from '../lib/common_elements.js'
 import Head from 'next/head'
 
 export default function DataSources () {
-  const faq = 'font-semibold mt-4 mb-1'
+  const faq = 'text-lg font-semibold mt-4 mb-1'
   const link = 'text-blue-500 hover:text-blue-300'
   const para = 'mb-2'
 
@@ -20,15 +20,17 @@ export default function DataSources () {
           The <a className={link} href='https://www.census.gov/construction/bps/'>Building Permits Survey</a> (BPS) is a survey of local governments on the number of new, privately-owned housing units they issued building permits for every year, issued by the US Census Bureau. (Some cities are surveyed every month, while some are surveyed annually.) The form they send out looks like <a className={link} href='https://www.census.gov/construction/bps/pdf/c404.pdf'>this</a>.
         </p>
         <h2 className={faq}>What does "permitted" mean?</h2>
-        <p className={para}>Not every housing unit that receives a permit is actually built. Some fraction of "housing permits" becomes a "housing start", and then some fraction of those become "housing completions".</p>
-        <p className={para}>The Census also does a survey on housing starts and completions as part of the <a className={link} href='https://www.census.gov/construction/nrc/nrcdatarelationships.html'>Survey of Construction (SOC)</a>. They report that overall, for single-family housing, starts were 2.5% greater than permits, and completions were 3.5% less than starts. For multifamily, starts were 22.5% less than permits, and completions were 7.5% less than starts. I might try to add SOC data here at some point.</p>
+        <p className={para}>Not every housing unit that receives a permit is actually built. Some fraction of "housing permits" start construction and become "housing starts", and then some fraction of those become "housing completions".</p>
+        <p className={para}>More detailed information on what fraction of permits become starts or completion is in the Census <a className={link} href='https://www.census.gov/construction/nrc/nrcdatarelationships.html'>Survey of Construction (SOC)</a>. Unlike the BPS, the SOC is done only on a sample of cities and building projects, so the data would be a little noisier.</p>
+        <p className={para}>To get an overall sense of what fraction of permits become starts or completions: the SOC reports that for single-family housing, starts are usually 2.5% greater than permits, and completions 3.5% less than starts. For multifamily, starts are generally 22.5% less than permits, and completions 7.5% less than starts. I might add SOC data here at some point.</p>
 
         <h2 className={faq}>How accurate is the data?</h2>
         <p className={para}>I'm not sure! They claim that only <a className={link} href='https://www.census.gov/construction/bps/how_the_data_are_collected/#nonresponse'>5% of rows</a> in the 2019 annual data survey had to be imputed because of nonresponse, but that doesn't mean that the officials in each city know how to fill out the form accurately. From other folks who've played with this data, I've gathered that the data is generally more reliable for bigger cities, whose bureaucracy is presumably more competent at filling out these forms, and less so for small towns.</p>
         <h2 className={faq}>I think some of the numbers here look wrong?</h2>
         <p className={para}>The Census Bureau has their own <a className={link} href='https://socds.huduser.gov/permits/'>tool</a> for making tables from the BPS, so trying the same state/city and year there and comparing the two numbers might be a good start.</p>
-        <h2 className={faq}>Where is the population data from?</h2>
-        <p className={para}>Most of the data is from Census yearly intercensal estimates. The only exception is places/cities only for the years 1981–1989, for which intercensal estimates weren't available, so I had to take the Census's decade estimates (for 1980 and 1990) and linearly interpolate between those two. In most cases the approximation shouldn't affect things too much (this isn't <em>that</em> different from how the census creates intercensal estimates) but for extremely small cities that may cause some issues.</p>
+        <h2 className={faq}>How are per capita number computed?</h2>
+        <p className={para}>The "per capita units" number is just the number of new permitted units in one year divided by the Census population estimate for that year (the July 1 estimate). The plots are shown as "units permitted per 1000 residents" so that the numbers are in a scale that is easier to understand. Most cities build somewhere between 1 to 15 units per 1000 population per year.</p>
+        <p className={para}>Most of the population data is from Census yearly intercensal estimates. The only exception is places/cities for the years 1981–1989, for which intercensal estimates weren't available, and so I had to take the Census's decade estimates (for 1980 and 1990) and linearly interpolate between those two. In most cases the approximation shouldn't affect things too much (this isn't <em>that</em> different from how the census creates intercensal estimates) but for extremely small cities that may cause some issues.</p>
         <h2 className={faq}>Can I play with the data?</h2>
         <p className={para}>Yes! The data for states, metros, counties, and places/cities are available at:</p>
         <ul className={para + ' list-disc list-inside ml-2'}>

--- a/python/housing_data/build_data.py
+++ b/python/housing_data/build_data.py
@@ -88,6 +88,8 @@ def load_states():
     for col in NUMERICAL_COLUMNS:
         states_df[col + "_per_capita"] = states_df[col] / states_df["population"]
 
+    states_df.to_parquet(PUBLIC_DIR / "states_annual.parquet")
+
     states_df.to_json(PUBLIC_DIR / "state_annual.json", orient="records")
 
 
@@ -315,7 +317,7 @@ def load_places(counties_population_df: pd.DataFrame = None) -> pd.DataFrame:
 
     add_alt_names(raw_places_df)
 
-    raw_places_df.to_parquet(PUBLIC_DIR / "places_annual_without_population.parquet")
+    # raw_places_df.to_parquet(PUBLIC_DIR / "places_annual_without_population.parquet")
 
     place_populations_df = place_population.get_place_population_estimates()
 
@@ -392,7 +394,7 @@ def load_counties(
         metadata_df, on=["fips_state", "fips_county"], how="left"
     )
 
-    counties_df.to_parquet(PUBLIC_DIR / "counties_annual_without_population.parquet")
+    # counties_df.to_parquet(PUBLIC_DIR / "counties_annual_without_population.parquet")
 
     if population_df is None:
         population_df = county_population.get_county_population_estimates()

--- a/python/housing_data/build_data.py
+++ b/python/housing_data/build_data.py
@@ -334,8 +334,6 @@ def load_places(counties_population_df: pd.DataFrame = None) -> pd.DataFrame:
 
         place_populations_df = pd.concat([place_populations_df, nyc_counties_df])
 
-    # place_populations_df.to_parquet(PUBLIC_DIR / "places_population.parquet")
-
     places_df = add_population_data(raw_places_df, place_populations_df)
     places_df.to_parquet(PUBLIC_DIR / "places_annual.parquet")
 
@@ -393,8 +391,6 @@ def load_counties(
     counties_df = counties_df.drop(columns=["county_name"]).merge(
         metadata_df, on=["fips_state", "fips_county"], how="left"
     )
-
-    # counties_df.to_parquet(PUBLIC_DIR / "counties_annual_without_population.parquet")
 
     if population_df is None:
         population_df = county_population.get_county_population_estimates()


### PR DESCRIPTION
* Show per-capita units plots in "units per 1000 residents" instead of per capita
* Rotate the y-axis label 90 degrees to make it easier to read
* Increase text size for axes labels/ticks in bar plots
* Update FAQ page with population data and raw data parquet URL
* Don't save intermediate parquet files to disk (were only used in debugging)