### PR TITLE
Distinguish single-city MSAs from cities in comparison view

### DIFF
--- a/lib/MetroPlots.tsx
+++ b/lib/MetroPlots.tsx
@@ -19,6 +19,7 @@ type RawOption = {
   path: string
   name: string
   metro_name: string
+  metro_name_with_suffix: string
   metro_type: string
   county_names: string[]
   population: number

--- a/lib/MetroPlots.tsx
+++ b/lib/MetroPlots.tsx
@@ -29,6 +29,7 @@ type Option = {
   path: string
   name: string
   metro_name: string
+  metro_name_with_suffix: string
   metro_type: string
   county_names: string[]
 }
@@ -51,6 +52,7 @@ export function makeOptions(
     const option = {
       value: metro.path,
       name: metro.metro_name,
+      name_with_suffix: metro.metro_name_with_suffix,
       path: getJsonUrl(metro.path),
       metro_type: metro.metro_type,
       county_names: metro.county_names,
@@ -68,7 +70,9 @@ export function makeOptions(
 
   return [
     {
-      name: "CBSAs",
+      // I've removed all the μSAs, so the CBSAs list will only include the MSAs.
+      // TODO: Replace "CBSA" with "MSA" throughout the code base.
+      name: "MSAs",
       type: "group",
       items: cbsaOptions,
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -268,7 +268,9 @@ function addPrefixes(options, prefix, use_metro_name_suffix = false) {
   const newOptions = []
   for (const option of options) {
     // IDK if we want name or value... let's just go with name for now.
-    const changes = { value: prefix + "/" + option.name }
+    const changes: { value: string; name?: string } = {
+      value: prefix + "/" + option.name,
+    }
     if (use_metro_name_suffix) {
       changes.name = option.name_with_suffix
     }

--- a/python/housing_data/build_metros.py
+++ b/python/housing_data/build_metros.py
@@ -145,9 +145,8 @@ def load_metros(counties_df: pd.DataFrame) -> None:
 
     metros_df["path"] = metros_df["metro_name"].str.replace("/", "-")
 
-    # This field is only used in comparison plots. In that case, we would like to use the
-    # full metro name with the "MSA" or "CSA" suffix.
-    # In other pages, I don't think this field is used.
+    # This field is only used in comparison plots in the plotting code.
+    # For the plot labels, would like to use the full metro name with the "MSA" or "CSA" suffix.
     metros_df["name"] = metros_df["metro_name_with_suffix"]
 
     metros_df.to_parquet(PUBLIC_DIR / "metros_annual.parquet")


### PR DESCRIPTION
Currently metro names are displayed in the comparison view (both the dropdown and the chart label) as "[MSA name], [state]". This means that metros named after just one city, such as the Madison, WI metro area, are displayed as just "Madison, WI", which means that we can't distinguish between the Madison metro area and Madison the city.
It also messes up the plot, only one line is shown rather than two if you select both the Madison metro area and the city.

This fixes this mistake by, in the comparison view only, appending "MSA" or "CSA" to the metro name in both the dropdown and the chart view.

This also makes a minor change to the "Metros" bar plot change, renaming "CBSA" to "MSA". And it removes the Micropolitan Statistical Areas from the dataset, since most people don't care about them.