### PR TITLE
Add Jan 2022 data!

### DIFF
--- a/lib/BarPlot.tsx
+++ b/lib/BarPlot.tsx
@@ -1,4 +1,4 @@
-import { fieldsGenerator } from "lib/plots"
+import { fieldsGenerator } from "../lib/plots"
 import ContainerDimensions from "react-container-dimensions"
 import { VegaLite } from "react-vega"
 import { TopLevelSpec } from "vega-lite"

--- a/lib/BarPlot.tsx
+++ b/lib/BarPlot.tsx
@@ -1,10 +1,11 @@
-import { fieldsGenerator } from "../lib/plots"
+import { fieldsGenerator } from "lib/plots"
 import ContainerDimensions from "react-container-dimensions"
 import { VegaLite } from "react-vega"
 import { TopLevelSpec } from "vega-lite"
 import { Transform } from "vega-lite/src/transform"
 import { StringFieldDef } from "vega-lite/src/channeldef"
 import { PlainObject } from "react-vega/src/types"
+import { projectedUnitsLabel } from "lib/projections"
 
 const unitsLabels = {
   units: "Units permitted",
@@ -25,9 +26,9 @@ const baseKeyMapping = {
   "5_plus_units_units": "5+ units",
   "5_plus_units_bldgs": "5+ units",
   "5_plus_units_value": "5+ units",
-  projected_units: "Projected units, 2021*",
-  projected_bldgs: "Projected units, 2021*",
-  projected_value: "Projected units, 2021*",
+  projected_units: projectedUnitsLabel,
+  projected_bldgs: projectedUnitsLabel,
+  projected_value: projectedUnitsLabel,
 }
 
 const baseOrderMapping = {
@@ -85,13 +86,13 @@ export default function BarPlot({
           <pattern
             id="diagonalHatch"
             patternUnits="userSpaceOnUse"
-            width="4"
-            height="4"
+            width="6"
+            height="6"
           >
             <path
-              d="M-1,1 l2,-2 M0,4 l4,-4 M3,5 l2,-2"
-              stroke="black"
-              strokeWidth="1"
+              d="M-1,1 l2,-2 M0,6 l6,-6 M5,7 l2,-2"
+              stroke="rgb(64, 64, 64)"
+              strokeWidth="1.5"
             />
           </pattern>
         </defs>
@@ -187,7 +188,12 @@ function makeSpec(
       x: {
         field: "year",
         type: "temporal",
-        axis: { title: "Year", titleFontSize: 13, labelFontSize: 14 },
+        axis: {
+          title: "Year",
+          titleFontSize: 13,
+          labelFontSize: 14,
+          grid: false,
+        },
       },
       y: {
         field: "value",
@@ -238,8 +244,7 @@ function makeSpec(
                 "2 units",
                 "3-4 units",
                 "5+ units",
-                // Commenting out for now, since we have data for all of 2021. Will uncomment when we get Jan 2022.
-                // "Projected units, 2021*",
+                projectedUnitsLabel,
               ],
               // Taken from Tableau 10 (https://www.tableau.com/about/blog/2016/7/colors-upgrade-tableau-10-56782)
               range: [
@@ -247,7 +252,7 @@ function makeSpec(
                 "#f28e2b",
                 "#e15759",
                 "#76b7b2",
-                // "url(#diagonalHatch)",
+                "url(#diagonalHatch)",
               ],
             },
           },
@@ -265,12 +270,11 @@ function makeSpec(
             { field: "3_to_4_units_units", title: "3-4 units", format: "," },
             { field: "5_plus_units_units", title: "5+ units", format: "," },
             { field: "total_units", title: "Total units", format: "," },
-            // Will uncomment when we have Jan 2022 data.
-            // {
-            //   field: "projected_units",
-            //   title: "Projected units, 2021",
-            //   format: ",",
-            // },
+            {
+              field: "projected_units",
+              title: projectedUnitsLabel,
+              format: ",",
+            },
           ],
         },
       },

--- a/lib/CountyPlots.tsx
+++ b/lib/CountyPlots.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from "next/router"
-import BarPlot from "lib/BarPlot"
+import BarPlot from "./BarPlot"
 import { useMemo, useCallback } from "react"
-import { useFetch } from "lib/queries"
+import { useFetch } from "./queries"
 import us from "us"
 import WindowSelectSearch from "lib/WindowSelectSearch"
-import { makeUnitsSelect, usePerCapitaInput } from "lib/selects"
-import { PathMapping } from "lib/utils"
+import { makeUnitsSelect, usePerCapitaInput } from "../lib/selects"
+import { PathMapping } from "../lib/utils"
 import { CurrentYearExtrapolationInfo } from "lib/projections"
 
 function getStateAbbreviation(stateCode: number): string {

--- a/lib/CountyPlots.tsx
+++ b/lib/CountyPlots.tsx
@@ -1,12 +1,12 @@
 import { useRouter } from "next/router"
-import BarPlot from "./BarPlot"
+import BarPlot from "lib/BarPlot"
 import { useMemo, useCallback } from "react"
-import { useFetch } from "./queries"
+import { useFetch } from "lib/queries"
 import us from "us"
 import WindowSelectSearch from "lib/WindowSelectSearch"
-import { makeUnitsSelect, usePerCapitaInput } from "../lib/selects"
-import { PathMapping } from "../lib/utils"
-import { CurrentYearExtrapolationInfo } from "./common_elements"
+import { makeUnitsSelect, usePerCapitaInput } from "lib/selects"
+import { PathMapping } from "lib/utils"
+import { CurrentYearExtrapolationInfo } from "lib/projections"
 
 function getStateAbbreviation(stateCode: number): string {
   const twoDigitStringCode = String(stateCode).padStart(2, "0")

--- a/lib/MetroPlots.tsx
+++ b/lib/MetroPlots.tsx
@@ -5,7 +5,7 @@ import { useFetch } from "lib/queries"
 import WindowSelectSearch from "lib/WindowSelectSearch"
 import { makeUnitsSelect, usePerCapitaInput } from "lib/selects"
 import { PathMapping, scoreFnWithPopulation } from "lib/utils"
-import { CurrentYearExtrapolationInfo } from "./common_elements"
+import { CurrentYearExtrapolationInfo } from "lib/projections"
 
 function getJsonUrl(metro: string): string {
   if (metro === null || typeof metro === "undefined") {

--- a/lib/PlacePlots.tsx
+++ b/lib/PlacePlots.tsx
@@ -6,7 +6,7 @@ import us from "us"
 import { useRouter } from "next/router"
 import { makeUnitsSelect, usePerCapitaInput } from "lib/selects"
 import { PathMapping, scoreFnWithPopulation } from "lib/utils"
-import { CurrentYearExtrapolationInfo } from "./common_elements"
+import { CurrentYearExtrapolationInfo } from "lib/projections"
 
 export function getJsonUrl(place: string, state: string): string {
   if (place === null) {

--- a/lib/StatePlots.tsx
+++ b/lib/StatePlots.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from "next/router"
-import { useFetch } from "lib/queries"
+import { useFetch } from "../lib/queries"
 import SelectSearch from "react-select-search/dist/cjs"
 import { useMemo } from "react"
-import BarPlot from "lib/BarPlot"
-import { makeUnitsSelect, usePerCapitaInput } from "lib/selects"
+import BarPlot from "../lib/BarPlot"
+import { makeUnitsSelect, usePerCapitaInput } from "../lib/selects"
 import { PlainObject } from "react-vega/src/types"
 import { CurrentYearExtrapolationInfo } from "lib/projections"
 

--- a/lib/StatePlots.tsx
+++ b/lib/StatePlots.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from "next/router"
-import { useFetch } from "../lib/queries"
+import { useFetch } from "lib/queries"
 import SelectSearch from "react-select-search/dist/cjs"
 import { useMemo } from "react"
-import BarPlot from "../lib/BarPlot"
-import { makeUnitsSelect, usePerCapitaInput } from "../lib/selects"
+import BarPlot from "lib/BarPlot"
+import { makeUnitsSelect, usePerCapitaInput } from "lib/selects"
 import { PlainObject } from "react-vega/src/types"
-import { CurrentYearExtrapolationInfo } from "./common_elements"
+import { CurrentYearExtrapolationInfo } from "lib/projections"
 
 type RawOption = {
   type: string

--- a/lib/common_elements.tsx
+++ b/lib/common_elements.tsx
@@ -2,23 +2,6 @@ import Link from "next/link"
 import Head from "next/head"
 import { useState, useCallback } from "react"
 
-export function CurrentYearExtrapolationInfo(props): JSX.Element {
-  return <></>
-
-  // Can go back to this logic when we have Jan 2022 data.
-  return (
-    <div>
-      <div className="text-xs mt-3 text-left">
-        *2021 includes data from January–November.
-      </div>
-      <div className="text-xs text-left">
-        &nbsp;The remainder of the year is extrapolated from the monthly rate
-        from January to November 2021.
-      </div>
-    </div>
-  )
-}
-
 export function GitHubFooter(props): JSX.Element {
   const linkClasses = "text-blue-500 hover:text-blue-300"
 

--- a/lib/plots.ts
+++ b/lib/plots.ts
@@ -1,8 +1,8 @@
 export function* fieldsGenerator(
-  types = ["bldgs", "units", "value"],
-  suffixes = ["_reported", ""],
-  perCapitaSuffixes = ["", "_per_capita", "_per_capita_per_1000"]
-) {
+  types: string[] = ["bldgs", "units", "value"],
+  suffixes: string[] = ["_reported", ""],
+  perCapitaSuffixes: string[] = ["", "_per_capita", "_per_capita_per_1000"]
+): IterableIterator<string> {
   for (const numUnits of [
     "1_unit",
     "2_units",

--- a/lib/projections.tsx
+++ b/lib/projections.tsx
@@ -1,0 +1,38 @@
+const currentYear = "2022"
+export const projectedUnitsLabel = `Projected units, ${currentYear}*`
+
+const months = {
+  1: "January",
+  2: "February",
+  3: "March",
+  4: "April",
+  5: "May",
+  6: "June",
+  7: "July",
+  8: "August",
+  9: "September",
+  10: "October",
+  11: "November",
+  12: "December",
+}
+
+const latestMonth: number = 1
+const glueWord = latestMonth == 2 ? "and" : "through"
+const observedMonths =
+  latestMonth == 1
+    ? months[latestMonth]
+    : `${months[1]} ${glueWord} ${months[latestMonth]}`
+
+export function CurrentYearExtrapolationInfo(props): JSX.Element {
+  return (
+    <div>
+      <div className="text-xs mt-3 text-left">
+        *{currentYear} includes data from {observedMonths}.
+      </div>
+      <div className="text-xs text-left">
+        &nbsp;The remainder of the year is extrapolated from the monthly rate
+        from {observedMonths} {currentYear}.
+      </div>
+    </div>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -360,7 +360,9 @@ function getData(path: string): object {
 }
 
 function combineDatas(datas) {
-  const data = datas.flatMap((d) => d.data ?? [])
+  const data = datas
+    .flatMap((d) => d.data ?? [])
+    .filter((d) => d.year != "2022")
 
   const dataCopied = []
   for (const row of data) {

--- a/python/housing_data/county_population.py
+++ b/python/housing_data/county_population.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import us
+from housing_data.build_data_utils import impute_2020s_population
 from housing_data.data_loading_helpers import get_path, get_url_text
 
 if TYPE_CHECKING:
@@ -219,13 +220,6 @@ def get_county_populations_1980s(data_path: Optional[Path] = None) -> pd.DataFra
     return combined_df
 
 
-def impute_county_populations_2021(df_2010s: pd.DataFrame) -> pd.DataFrame:
-    """
-    Impute 2021 with the 2020 population; that's the best I think we can do...
-    """
-    return df_2010s[df_2010s["year"] == "2020"].assign(year="2021")
-
-
 def get_county_population_estimates(data_path: Optional[Path] = None):
     print("Loading 1980 populations...")
     df_1980s = get_county_populations_1980s(data_path)
@@ -236,9 +230,9 @@ def get_county_population_estimates(data_path: Optional[Path] = None):
     print("Loading 2010s populations...")
     df_2010s = get_county_populations_2010s(data_path)
 
-    df_2021 = impute_county_populations_2021(df_2010s)
+    df_2020s = impute_2020s_population(df_2010s)
 
-    df = pd.concat([df_1980s, df_1990s, df_2000s, df_2010s, df_2021])
+    df = pd.concat([df_1980s, df_1990s, df_2000s, df_2010s, df_2020s])
 
     # Check for dupes
     assert (df.groupby(["county_code", "state_code", "year"]).size() == 1).all()

--- a/python/housing_data/place_population.py
+++ b/python/housing_data/place_population.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 import requests
+from housing_data.build_data_utils import impute_2020s_population
 from housing_data.data_loading_helpers import get_path
 
 if TYPE_CHECKING:
@@ -465,13 +466,6 @@ def interpolate_1980s_populations(
     return interp_df
 
 
-def impute_place_populations_2021(df_2010s: pd.DataFrame) -> pd.DataFrame:
-    """
-    Impute 2021 with the 2020 population; that's the best I think we can do...
-    """
-    return df_2010s[df_2010s["year"] == "2020"].assign(year="2021")
-
-
 def get_place_population_estimates(data_path: Optional[Path] = None):
     print("Loading 1980 populations...")
     df_1980 = get_place_populations_1980(data_path)
@@ -497,8 +491,8 @@ def get_place_population_estimates(data_path: Optional[Path] = None):
     print("Interpolating 1980s populations...")
     interp_df = interpolate_1980s_populations(df_1980, df_1990s)
 
-    df_2021 = impute_place_populations_2021(df_2010s)
+    df_2020s = impute_2020s_population(df_2010s)
 
-    combined_df = pd.concat([interp_df, df_1990s, df_2000s, df_2010s, df_2021])
+    combined_df = pd.concat([interp_df, df_1990s, df_2000s, df_2010s, df_2020s])
 
     return combined_df

--- a/python/housing_data/state_population.py
+++ b/python/housing_data/state_population.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import us
+from housing_data.build_data_utils import impute_2020s_population
 from housing_data.data_loading_helpers import get_path, get_url_text
 
 if TYPE_CHECKING:
@@ -254,13 +255,6 @@ def get_state_populations_2010s(data_path: Optional[Path] = None) -> pd.DataFram
     )
 
 
-def impute_state_populations_2021(df_2010s: pd.DataFrame) -> pd.DataFrame:
-    """
-    Impute 2021 with the 2020 population; that's the best I think we can do...
-    """
-    return df_2010s[df_2010s["year"] == "2020"].assign(year="2021")
-
-
 def get_state_population_estimates(data_path: Optional[Path] = None):
     print("Loading 1980s data...")
     df_1980s = get_state_populations_1980s(data_path)
@@ -274,9 +268,9 @@ def get_state_population_estimates(data_path: Optional[Path] = None):
     print("Loading 2010s data...")
     df_2010s = get_state_populations_2010s(data_path)
 
-    df_2021 = impute_state_populations_2021(df_2010s)
+    df_2020s = impute_2020s_population(df_2010s)
 
-    states_df = pd.concat([df_1980s, df_1990s, df_2000s, df_2010s, df_2021])
+    states_df = pd.concat([df_1980s, df_1990s, df_2000s, df_2010s, df_2020s])
 
     states = us.states.mapping("name", "fips").keys()
     states_df = states_df[states_df["state"].isin(states)]


### PR DESCRIPTION
Also remove vertical grid ticks from the bar plots (they look especially ugly when I add the diagonal dashed line pattern for projected units)

Some metros look a little weird because they have 2022 data but not 2021 (I think because BPS changed their methodology for which counties to request monthly data from)... that's okay, I think it'll only be an issue for the next 3 months. Shouldn't happen next year