### PR TITLE
Fix duplicates

### DIFF
--- a/python/housing_data/build_metros.py
+++ b/python/housing_data/build_metros.py
@@ -126,15 +126,7 @@ def load_metros(counties_df: pd.DataFrame) -> pd.DataFrame:
 
     merged_df = crosswalk_df.merge(
         counties_df, on=["fips_state", "fips_county"], how="left"
-    ).drop(
-        columns=[
-            "fips_state",
-            "fips_county",
-            "region_code",
-            "division_code",
-            "survey_date",
-        ]
-    )
+    ).drop(columns=["fips_state", "fips_county"])
 
     msas_df = combine_metro_rows(merged_df, "msa", crosswalk_df)
     csas_df = combine_metro_rows(merged_df, "csa", crosswalk_df)

--- a/python/housing_data/build_places.py
+++ b/python/housing_data/build_places.py
@@ -18,7 +18,10 @@ def make_bps_fips_mapping(
     places_df: pd.DataFrame, place_population_df: pd.DataFrame
 ) -> pd.DataFrame:
     """
-    Returns a DataFrame with columns: 6_digit_id, state_code, place_or_county_code
+    Returns a DataFrame with columns:
+    - 6_digit_id (str)
+    - state_code (int)
+    - place_or_county_code (str)
     """
     # The most recent years have fips code in BPS, so we'll use those to join.
     # Some years will have the same BPS 6-digit ID, so we can join roughly 1992 to present using that.
@@ -27,7 +30,6 @@ def make_bps_fips_mapping(
         ["place_name", "fips place_code", "county_code", "state_code", "6_digit_id"]
     ].copy()
 
-    # For it to be a mapping, each BPS ID should appear only once per state...
     assert (mapping.groupby(["6_digit_id", "state_code"]).size() == 1).all()
 
     fips_place_code_str = mapping["fips place_code"].astype(str).replace("<NA>", "")
@@ -37,7 +39,7 @@ def make_bps_fips_mapping(
         ~mapping["fips place_code"].isin([0, 99990]), county_code_str + "_county"
     )
 
-    # Fix NYC boroughs: we don't want to use the whole city population as the denominator in per-capite calculations
+    # Fix NYC boroughs: we don't want to use the whole city population as the denominator in per-capita calculations
     # for the borough plots.
     # The boroughs all have place_or_county_code = 51000, state_code = 36, and place_name = the borough name.
     # The third condition below is needed because there is also a "New York City" total row which has the same state and
@@ -68,22 +70,29 @@ def make_bps_fips_mapping(
 
 
 def make_place_name_fips_mapping(merged_rows: pd.DataFrame) -> pd.DataFrame:
+    """
+    Returns a DataFrame with columns:
+    - place_name (str)
+    - state_code (int)
+    - place_or_county_code (str)
+
+    This is used to map recent (post-1992) rows to old (pre-1992) rows, since
+    the 6-digit IDs changed and the old rows don't have FIPS codes either.
+
+    This is not great, because it throws out towns with similar names
+    (e.g. Albion town, NY and Albion village, NY).
+    We should probably use the "town", "village", etc. designations for
+    matching instead of throwing them away.
+    """
     mapping = merged_rows[
         ["place_name", "state_code", "place_or_county_code"]
     ].drop_duplicates()
 
     # Remove dupes ( (place_name, state_code) tuples for which there are multiple fips codes)
-    dupes = mapping.groupby(["place_name", "state_code"]).size().loc[lambda x: x > 1]
-    mapping = (
-        mapping.merge(
-            dupes.rename("dupe_count").reset_index().drop(columns=["dupe_count"]),
-            on=["place_name", "state_code"],
-            how="left",
-            indicator=True,
-        )
-        .loc[lambda df: df["_merge"] == "left_only"]
-        .drop(columns=["_merge"])
-    )
+    # TODO: some of these are probably cases of a village and a township with the same name,
+    # or something like that. We can probably deal with this instead of throwing them all out
+    dupes = mapping.duplicated(subset=["place_name", "state_code"], keep=False)
+    mapping = mapping[~dupes].copy()
 
     # For this to be used as a mapping, it must also satisfy this property
     assert (mapping.groupby(["place_name", "state_code"]).size() == 1).all()
@@ -94,12 +103,22 @@ def make_place_name_fips_mapping(merged_rows: pd.DataFrame) -> pd.DataFrame:
 def add_place_population_data(
     places_df: pd.DataFrame, place_population_df: pd.DataFrame
 ) -> pd.DataFrame:
+    """
+    Tries to add a population column to as many rows in places_df as possible.
+
+    The procedure is:
+    - Get a mapping from BPS 6-digit code to FIPS code, via 2019 data
+    - Use this to get FIPS codes for all post-1992 rows
+    - For pre-1992 rows, match them to recent rows via place name and state code.
+      This is lossy, because we throw out dupes (e.g. Albion town, NY and Albion village, NY).
+      TODO: fix this
+    """
     bps_fips_mapping = make_bps_fips_mapping(places_df, place_population_df)
 
     places_df = places_df.drop(columns=["fips place_code", "county_code"])
 
-    # BPS changed their 6-digit IDs starting in 1992. So for rows from before 1992, we add '_pre_1992'
-    # to the ID to distinguish them.
+    # BPS changed their 6-digit IDs starting in 1992. For rows before 1992, we add "_pre_1992"
+    # to distinguish them
     places_df["6_digit_id"] = (
         places_df["6_digit_id"]
         .astype(str)
@@ -143,7 +162,7 @@ def add_place_population_data(
     unmerged_rows_2 = unmerged_rows_2.drop(columns=["_merge"])
     places_with_fips_df = pd.concat([merged_rows, unmerged_rows_2])
 
-    # Finally, let's merge in population!
+    # Now that every row has a FIPS code, let's merge in population!
     final_places_df = places_with_fips_df.merge(
         place_population_df.drop(columns=["place_name"]),
         left_on=["place_or_county_code", "state_code", "year"],
@@ -216,7 +235,7 @@ def load_places(
 
     add_alt_names(raw_places_df)
 
-    # raw_places_df.to_parquet(PUBLIC_DIR / "places_annual_without_population.parquet")
+    raw_places_df.to_parquet(PUBLIC_DIR / "places_annual_without_population.parquet")
 
     place_populations_df = place_population.get_place_population_estimates(
         data_path=Path(data_repo_path, PLACE_POPULATION_DIR) if data_repo_path else None

--- a/python/housing_data/build_places.py
+++ b/python/housing_data/build_places.py
@@ -269,14 +269,11 @@ def fix_nyc_boroughs_population(
 def get_name_spelling(places_df: pd.DataFrame) -> pd.Series:
     name_spelling = get_place_name_spellings(places_df)
     name = pd.Series(
-        [
-            name_spelling[tuple(tup)]
-            for tup in places_df[["place_name", "place_type", "state_code"]].itertuples(
-                index=False
-            )
-        ],
+        places_df[["place_name", "place_type", "state_code"]].itertuples(
+            index=False, name=None
+        ),
         index=places_df.index,
-    )
+    ).map(name_spelling)
 
     # Add name for comparison plots
     is_unincorporated = places_df["place_name"].str.contains("County") | places_df[

--- a/python/housing_data/build_places.py
+++ b/python/housing_data/build_places.py
@@ -220,7 +220,9 @@ def add_alt_names(raw_places_df: pd.DataFrame) -> None:
     ] = "Manhattan Bronx Brooklyn Queens Staten Island"
 
 
-def get_place_name_spellings(df: pd.DataFrame) -> Dict[Tuple[str, Optional[str]], str]:
+def get_place_name_spellings(
+    df: pd.DataFrame,
+) -> Dict[Tuple[str, Optional[str], int], str]:
     """
     :param df: A DataFrame with columns place_name, place_type, and state_code.
 

--- a/python/housing_data/build_states.py
+++ b/python/housing_data/build_states.py
@@ -13,7 +13,6 @@ from housing_data.build_data_utils import (
 
 def load_states(data_repo_path: Optional[str]) -> pd.DataFrame:
     states_df = load_bps_all_years_plus_monthly(data_repo_path, "state")
-    # states_df = states_df.astype({"survey_date": str})
 
     population_df = state_population.get_state_population_estimates(
         Path(data_repo_path, STATE_POPULATION_DIR) if data_repo_path else None

--- a/python/housing_data/build_states.py
+++ b/python/housing_data/build_states.py
@@ -13,7 +13,7 @@ from housing_data.build_data_utils import (
 
 def load_states(data_repo_path: Optional[str]) -> pd.DataFrame:
     states_df = load_bps_all_years_plus_monthly(data_repo_path, "state")
-    states_df = states_df.astype({"survey_date": str})
+    # states_df = states_df.astype({"survey_date": str})
 
     population_df = state_population.get_state_population_estimates(
         Path(data_repo_path, STATE_POPULATION_DIR) if data_repo_path else None

--- a/python/housing_data/building_permits_survey.py
+++ b/python/housing_data/building_permits_survey.py
@@ -245,6 +245,7 @@ def load_data(
     month: Optional[int] = None,
     region: Optional[Region] = None,
     data_path: Optional[Path] = None,
+    drop_useless_fields: bool = True,
 ) -> pd.DataFrame:
     """
     :param region: Only required if scale is 'place'
@@ -269,6 +270,23 @@ def load_data(
 
     if scale == "county":
         df = county_cleanup(df)
+
+    if drop_useless_fields:
+        cols_to_drop = set(df.columns) & {
+            "survey_date",
+            "msa/cmsa",
+            "pmsa_code",
+            "region_code",
+            "division_code",
+            "central_city",
+            "zip_code",
+            "csa_csa",
+            "cbsa_code",
+            "csa_code",
+            "footnote_code",
+            "fips mcd_code",
+        }
+        df = df.drop(columns=list(cols_to_drop))
 
     return df
 

--- a/python/housing_data/building_permits_survey.py
+++ b/python/housing_data/building_permits_survey.py
@@ -486,7 +486,7 @@ def split_place_type(place_names: pd.Series, year: int) -> Tuple[pd.Series, pd.S
     title_place_types = [s.title() for s in place_types]
 
     new_place_names = []
-    extracted_place_types = []
+    extracted_place_types: List[Optional[str]] = []
     for name in place_names:
         for place_type, title_place_type in zip(place_types, title_place_types):
             if isinstance(name, str):

--- a/python/housing_data/place_population.py
+++ b/python/housing_data/place_population.py
@@ -31,15 +31,15 @@ def _get_places_crosswalk_df(data_path: Optional[Path] = None) -> pd.DataFrame:
 
 def get_unincorporated_places_populations_1980() -> pd.DataFrame:
     """
-    Manually computes the unincorporated population of each couty, by subtracting all
+    Manually computes the unincorporated population of each county, by subtracting all
     incorporated jurisdictions from the 1980 county population total.
 
     We need to do this because sadly nhgis_ds104_1980_place_02398.csv, which has rows for
     "remainder of X county", only includes 31 of 50-something states.
 
-    Anyways this is super easy to do, and probably ends up being less work than using/documenting how to use
-    the place_02398 dataset.
-    I verified that this method gives the same numbers as using that other dataset in the 31 states that are present.
+    This is super easy, probably less work than learning how to use the place_02398 dataset.
+    I verified that this method gives the same numbers as that other dataset in the
+    31 states that are present.
     """
     # TODO download programmatically, add header=1
     counties_df = pd.read_csv("../raw_data/nhgis0015_ds104_1980_county.csv", header=1)
@@ -339,10 +339,10 @@ def get_place_populations_1990s(data_path: Optional[Path]) -> pd.DataFrame:
 
     combined_df = remove_dupe_cities(combined_df)
 
-    combined_df = combined_df.drop(columns=["state_abbr"])
+    combined_df = combined_df.drop(columns=["state_abbr", "place_fips"])
 
     return combined_df.melt(
-        id_vars=["place_name", "state_code", "place_fips", "place_or_county_code"],
+        id_vars=["place_name", "state_code", "place_or_county_code"],
         var_name="year",
         value_name="population",
     )
@@ -467,6 +467,17 @@ def interpolate_1980s_populations(
 
 
 def get_place_population_estimates(data_path: Optional[Path] = None) -> pd.DataFrame:
+    """
+    Returns a DataFrame with the columns:
+    - state_code (int)
+    - place_or_county_code (str): either a place code (e.g. 12345) or a county code (e.g. 12345_county)
+    - place_name (str)
+    - year (str)
+    - population (float)
+
+    Note that county rows (e.g. "Los Angeles County", with state_code 6, place_or_county_code 37_county)
+    refers to the unincorporated county area population.
+    """
     print("Loading 1980 populations...")
     df_1980 = get_place_populations_1980(data_path)
     print("Loading 1990s populations...")


### PR DESCRIPTION
Currently we drop the place type (i.e. town, village, etc.) when cleaning up the place names.

If there are multiple place types for the same (place name, state) tuple, we combine them together into one plot. This is very wrong. (I'm not sure how we're getting the populations—maybe choosing an arbitrary one? And before #64 we were dropping all of these "duplicates"!)

This switches to a better solution: if there is only one place type for the (place name, state) tuple, don't include the place type in the name. If there are multiple (e.g. Marcellus town, NY, and Marcellus village, NY), include the full name for each.