### PR TITLE
Make bars wider

### DIFF
--- a/lib/BarPlot.tsx
+++ b/lib/BarPlot.tsx
@@ -185,6 +185,7 @@ function makeSpec(
       x: {
         field: "year",
         type: "temporal",
+        timeUnit: "utcyear",
         axis: {
           title: "Year",
           titleFontSize: 13,
@@ -224,6 +225,7 @@ function makeSpec(
         mark: {
           type: "bar",
           tooltip: { content: "data" },
+          width: { band: 0.7 },
         },
         encoding: {
           x: { field: "year" },
@@ -274,7 +276,7 @@ function makeSpec(
     ],
     config: {
       bar: {
-        continuousBandSize: continuousBandSize,
+        /* continuousBandSize: continuousBandSize, */
       },
     },
   }

--- a/lib/BarPlot.tsx
+++ b/lib/BarPlot.tsx
@@ -160,7 +160,6 @@ function makeSpec(
   const filterFields = Array.from(fieldsGenerator([units], [""], [suffix]))
 
   const plotWidth = Math.min(width * 0.92, 936)
-  const continuousBandSize = (plotWidth * 10) / 936
 
   const yLabel = unitsLabels[units]
   const yTitleSuffix = perCapita
@@ -274,10 +273,5 @@ function makeSpec(
         },
       },
     ],
-    config: {
-      bar: {
-        /* continuousBandSize: continuousBandSize, */
-      },
-    },
   }
 }


### PR DESCRIPTION
This makes the Canada ones look much less stupid, and also makes the US ones look better.

Arguably I should go all the way to 95% or whatever the default is (if I just remove the `width` parameter). I'm hesitant to change the UI so drastically though, so I'll just leave it like this for now.