### PR TITLE
Remove duplicate state rows for 2020

### DIFF
--- a/python/housing_data/state_population.py
+++ b/python/housing_data/state_population.py
@@ -212,9 +212,6 @@ def _melt_df(df: pd.DataFrame, years: List[int]) -> pd.DataFrame:
 
 
 def get_state_populations_2010s(data_path: Optional[Path]) -> pd.DataFrame:
-    """
-    This one goes through 2020
-    """
     df = pd.read_csv(
         get_path(
             "https://www2.census.gov/programs-surveys/popest/datasets/2010-2020/state/totals/nst-est2020-alldata.csv",
@@ -222,7 +219,7 @@ def get_state_populations_2010s(data_path: Optional[Path]) -> pd.DataFrame:
         )
     )
 
-    return _melt_df(df, list(range(2010, 2021)))
+    return _melt_df(df, list(range(2010, 2020)))
 
 
 def get_state_populations_2020s(data_path: Optional[Path]) -> pd.DataFrame:


### PR DESCRIPTION
The bar for 2020 shouldn't be twice as high as 2019 and 2021...

This is a bug introduced in #78. We have two population rows for 2020 (one from the 2010s dataset, one from the 2020s dataset), and when it gets joined to the BPS data we get two identical rows for 2020 for each state. This makes the bar look twice as high

<img width="1514" alt="Screenshot 2023-05-28 at 2 27 44 PM" src="https://github.com/sid-kap/housing-data/assets/6425077/a21f9bec-4a19-4b02-bc89-9fbeb4fc62b1">
