### PR TITLE
Use object URL API to allow downloading large JSON files

### DIFF
--- a/lib/PlotsTemplate.tsx
+++ b/lib/PlotsTemplate.tsx
@@ -44,8 +44,9 @@ export default function PlotsTemplate({
   jsonRoot: string
   countyList?: JSX.Element
 }): JSX.Element {
-  const url = selected != null ? jsonRoot + selected.value + ".json" : null
-  const { data } = useFetch(url)
+  const { data } = useFetch(
+    selected != null ? jsonRoot + selected.value + ".json" : null
+  )
 
   const { selectedUnits, unitsSelect } = useUnitsSelect()
 
@@ -85,7 +86,7 @@ export default function PlotsTemplate({
         <DownloadData
           data={data}
           name={selected?.name + ".json"}
-          selected={url}
+          selected={selected?.name}
         />
       </div>
     </div>

--- a/lib/PlotsTemplate.tsx
+++ b/lib/PlotsTemplate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
 
 import BarPlot from "lib/BarPlot"
 import { CurrentYearExtrapolationInfo } from "lib/projections"

--- a/lib/PlotsTemplate.tsx
+++ b/lib/PlotsTemplate.tsx
@@ -102,7 +102,7 @@ export function DownloadData({
   name: string
   selected: Any
 }): JSX.Element {
-  let url = useRef("#")
+  const url = useRef("#")
 
   // This runs every time selected changes
   useEffect(() => {

--- a/lib/PlotsTemplate.tsx
+++ b/lib/PlotsTemplate.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef, useState } from "react"
+
 import BarPlot from "lib/BarPlot"
 import { CurrentYearExtrapolationInfo } from "lib/projections"
 import { useFetch } from "lib/queries"
@@ -42,9 +44,8 @@ export default function PlotsTemplate({
   jsonRoot: string
   countyList?: JSX.Element
 }): JSX.Element {
-  const { data } = useFetch(
-    selected != null ? jsonRoot + selected.value + ".json" : null
-  )
+  const url = selected != null ? jsonRoot + selected.value + ".json" : null
+  const { data } = useFetch(url)
 
   const { selectedUnits, unitsSelect } = useUnitsSelect()
 
@@ -81,7 +82,11 @@ export default function PlotsTemplate({
             {selected?.has_ca_hcd_data && <HcdDataInfo />}
           </div>
         </div>
-        <DownloadData data={data} name={selected?.name + ".json"} />
+        <DownloadData
+          data={data}
+          name={selected?.name + ".json"}
+          selected={url}
+        />
       </div>
     </div>
   )
@@ -90,13 +95,27 @@ export default function PlotsTemplate({
 export function DownloadData({
   data,
   name,
+  selected,
 }: {
   data: object
   name: string
+  selected: Any
 }): JSX.Element {
+  let url = useRef("#")
+  useEffect(() => {
+    url.current = URL.createObjectURL(
+      new Blob([JSON.stringify(data)], { type: "octet/stream" })
+    )
+    // Cleanup function
+    return () => {
+      if (url.current != "#" && typeof window !== "undefined") {
+        URL.revokeObjectURL(url.current)
+      }
+    }
+  }, [selected])
   return (
     <a
-      href={"data:application/json," + JSON.stringify(data)}
+      href={url.current}
       className="text-sm text-blue-500 hover:text-blue-300"
       download={name}
     >

--- a/lib/PlotsTemplate.tsx
+++ b/lib/PlotsTemplate.tsx
@@ -100,7 +100,7 @@ export function DownloadData({
 }: {
   data: object
   name: string
-  selected: Any
+  selected: any
 }): JSX.Element {
   const url = useRef("#")
 

--- a/lib/PlotsTemplate.tsx
+++ b/lib/PlotsTemplate.tsx
@@ -102,6 +102,8 @@ export function DownloadData({
   selected: Any
 }): JSX.Element {
   let url = useRef("#")
+
+  // This runs every time selected changes
   useEffect(() => {
     url.current = URL.createObjectURL(
       new Blob([JSON.stringify(data)], { type: "octet/stream" })

--- a/lib/PlotsTemplate.tsx
+++ b/lib/PlotsTemplate.tsx
@@ -115,6 +115,7 @@ export function DownloadData({
       }
     }
   }, [selected])
+
   return (
     <a
       href={url.current}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -496,7 +496,11 @@ export default function Home(): JSX.Element {
         {perCapitaInput}
         {groupingInput}
         {selectedLocations.some((l) => l.has_ca_hcd_data) && preferHcdDataInput}
-        <DownloadData data={data} name="housing data comparisons.json" />
+        <DownloadData
+          data={data}
+          name="housing data comparisons.json"
+          selected={selectedLocations}
+        />
         {selectedLocations.some((l) => l.has_ca_hcd_data) && <HcdDataInfo />}
       </div>
     </Page>


### PR DESCRIPTION
#87 created truncated/unreadable files when the JSON was too big to fit in a data URL. This is a better way to create download links, which works for large files.